### PR TITLE
Make "madcap" and "madcap-vi" linkable.

### DIFF
--- a/blog/posts/which-programming-languages-use-indentation.scroll
+++ b/blog/posts/which-programming-languages-use-indentation.scroll
@@ -29,7 +29,7 @@ aftertext
  These languages use indentation:
 
 aftertext
- abc, aldor, boo, buddyscript, cobra, coffeescript, csl, curry, elixir, f-sharp, genie, haml, haskell, inform, iswim, literate-coffeescript, livescript, madcap-vi, madcap, makefile, markdown, miranda, nemerle, net-format, nim, occam, org, promal, python, restructuredtext, sass, scss, spin, stylus, xl-programming-language and yaml.
+ abc, aldor, boo, buddyscript, cobra, coffeescript, csl, curry, elixir, f-sharp, genie, haml, haskell, inform, iswim, literate-coffeescript, livescript, madcap, madcap-vi, makefile, markdown, miranda, nemerle, net-format, nim, occam, org, promal, python, restructuredtext, sass, scss, spin, stylus, xl-programming-language and yaml.
  link languages/abc.html abc
  link languages/aldor.html aldor
  link languages/boo.html boo


### PR DESCRIPTION
Hi Breck (@breck7)

In the original article only "madcap" is linked, but it is the first part of "madcap-vi" that contains the link. If a portion of text is repeated in "aftertext", which one get the link?

Kind Regards,
Liam