### PR TITLE
Add "Advent of Code" programming competition

### DIFF
--- a/blog/lists/competitions.scroll
+++ b/blog/lists/competitions.scroll
@@ -23,6 +23,7 @@ commaTable
  FacebookHackerCup,https://www.facebook.com/hackercup/,Programming,2011,Facebook_Hacker_Cup,https://en.wikipedia.org/wiki/Facebook_Hacker_Cup,USA
  HackerEarth,https://www.hackerearth.com/,Programming,2012,HackerEarth,https://en.wikipedia.org/wiki/HackerEarth,USA
  HackerRank,https://www.hackerrank.com,Programming,2012,HackerRank,https://en.wikipedia.org/wiki/HackerRank,USA
+ Advent of Code,https://adventofcode.com/,Programming,2015,https://en.wikipedia.org/wiki/Advent_of_Code,Online
 
 aftertext
  Is the PLDB missing a competition? @Edit this file@ and send a pull request.


### PR DESCRIPTION
>  Advent of Code is an annual set of Christmas-themed computer programming challenges that follow an Advent calendar. It has been running since 2015.

([Wikipedia](https://en.wikipedia.org/wiki/Advent_of_Code))

Given that [more than 200,000 competitors](https://adventofcode.com/2021/stats) have completed the first challenge in the 2021 Advent of Code event, and that it has a [leaderboard and ranking system](https://adventofcode.com/2021/leaderboard), I believe that Advent Of Code should be included in the list of programming competitions.