### PR TITLE
Stop failing silently if cloc is not installed

### DIFF
--- a/code/importers/cloc/setup.sh
+++ b/code/importers/cloc/setup.sh
@@ -1,4 +1,6 @@
 cd "$(dirname "$0")"
+command -v croc ||  echo "Install cloc and rerun"
+command -v croc ||  exit 125
 mkdir cache
 cd cache
 cloc --write-lang-def=my_definitions.txt

--- a/code/importers/cloc/setup.sh
+++ b/code/importers/cloc/setup.sh
@@ -1,6 +1,6 @@
 cd "$(dirname "$0")"
-command -v croc ||  echo "Install cloc and rerun"
-command -v croc ||  exit 125
+command -v  cloc ||  echo "Install cloc and rerun"
+command -v cloc ||  exit 125
 mkdir cache
 cd cache
 cloc --write-lang-def=my_definitions.txt


### PR DESCRIPTION
Stops silent failure of setup script if croc is not present on build machine.