### PR TITLE
Fix Github Language Stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.pldb linguist-language=pldb
+*.grammar linguist-language=Grammar

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.pldb linguist-language=pldb
 *.grammar linguist-language=Grammar
+*.scroll linguist-language=Scroll


### PR DESCRIPTION
Using Github's Feature `.gitattributes` file to manually define the languages
present in the repository.