### PR TITLE
Configure delete of white space in grammar files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v1.2.3
+    hooks:
+    -   id: trailing-whitespace


### PR DESCRIPTION
# Feature
Configuring auto deletion of white/trailing spaces before committing.

Using the [Pre-commit](https://pre-commit.com/) to achieve this. #179 
Pre-commit hook has been setup in the ***`.git/hooks/pre-commit`*** file

<img width="1000" alt="Screenshot 2022-10-05 at 00 40 16" src="https://user-images.githubusercontent.com/48904725/193935421-cc5a3c25-5a3e-4d3e-874a-8eed5d1a3f14.png">


Tested the feature locally and works fine. Further and keen testing is still required.

Cheers!