### PR TITLE
Remove books for Red language

### DIFF
--- a/database/things/red.pldb
+++ b/database/things/red.pldb
@@ -226,13 +226,6 @@ wordRank 554
 isOpenSource true
 centralPackageRepositoryCount 0
 
-isbndb 4
- year|publisher|title|authors|isbn13
- 1997|Sams|Red Hat Linux Unleashed|Pitts, David|9780672311734
- 2005|Sams|Red Hat Fedora 4: Unleashed|Hudson, Paul and Ball, Bill and Duff, Hoyt|9780672327926
- 2003|For Dummies|Red Hat Linux All-in-One Desk Reference For Dummies|Barkakati, Naba|9780764524424
- 2004|Sams|Red Hat Linux Fedora Unleashed|Ball, Bill and Duff, Hoyt|9780672326295
+isbndb 0
 
-semanticScholar 1
- year|title|doi|citations|influentialCitations|authors|paperId
- 2011|Research on red wave and green wave coordinated control model in arterial road for different traffic demands|10.1109/ICMT.2011.6003197|3|0|Shujian Zheng and Jian-min Xu|6724aad495f178db0c31374d4677ed7ac4c81ee6
+semanticScholar 0


### PR DESCRIPTION
The cited books are related to Red Hat Linux and not to the Red language itself.