### PR TITLE
Update link for Z Shell screenshot

### DIFF
--- a/database/things/z-shell.pldb
+++ b/database/things/z-shell.pldb
@@ -1,7 +1,7 @@
 title Z shell
 appeared 1990
 type pl
-screenshot https://commons.wikimedia.org/wiki/File:Zsh_5.8_screenshot.png
+screenshot https://upload.wikimedia.org/wikipedia/commons/thumb/d/da/Zsh_5.8_screenshot.png/800px-Zsh_5.8_screenshot.png
 demoVideo https://www.youtube.com/watch?v=MSPu-lYF-A8
 creators Paul Falstad
 website http://www.zsh.org/


### PR DESCRIPTION
The conversion of the scroll file to `z-shell.html` is generating an error:

![z-shell-no-such-file-error](https://user-images.githubusercontent.com/11787866/196285979-c2bdf2cd-4c8d-4975-987a-46f8d68e65ad.png)

The current link is to the page describing the PNG file, but not an actual link to the PNG itself. Here is the updated link:

https://upload.wikimedia.org/wikipedia/commons/thumb/d/da/Zsh_5.8_screenshot.png/800px-Zsh_5.8_screenshot.png