### PR TITLE
fp3.pldb: Remove single quotes in Description

### DIFF
--- a/database/things/fp3.pldb
+++ b/database/things/fp3.pldb
@@ -17,6 +17,6 @@ githubRepo https://github.com/japiirainen/fp
  firstCommit 2022
  stars 56
  forks 0
- description a programming language inspired by the `fp` language described in the 1977 Turing Award lecture by John Backus.
+ description a programming language inspired by the fp language described in the 1977 Turing Award lecture by John Backus.
 
 centralPackageRepositoryCount 0


### PR DESCRIPTION
The single quotes break the "didTheTestsPass" (see #291 jobs).