### PR TITLE
add faq release urls

### DIFF
--- a/database/things/delphi.pldb
+++ b/database/things/delphi.pldb
@@ -87,6 +87,7 @@ stackOverflowSurvey
 releaseNotesUrl https://edn.embarcadero.com/article/40775
 officialBlogUrl https://blogs.embarcadero.com/
 eventsPageUrl https://www.embarcadero.com/events
+faqPageUrl https://www.embarcadero.com/products/delphi/faq
 
 subreddit https://reddit.com/r/delphi
  memberCount

--- a/database/things/elm.pldb
+++ b/database/things/elm.pldb
@@ -221,6 +221,8 @@ rijuRepl https://riju.codes/elm
 
 indeedJobs elm engineer
  2017 127
+officialBlogUrl https://elm-lang.org/news
+faqPageUrl https://faq.elm-community.org/
 
 tiobe Elm
 

--- a/database/things/erlang.pldb
+++ b/database/things/erlang.pldb
@@ -180,6 +180,8 @@ stackOverflowSurvey
   fans 1379
   percentageUsing 0.01
 releaseNotesUrl https://www.erlang.org/news
+faqPageUrl https://www.erlang.org/faq/introduction.html
+officialBlogUrl https://www.erlang.org/blog
 
 subreddit https://reddit.com/r/erlang
  memberCount

--- a/database/things/maple.pldb
+++ b/database/things/maple.pldb
@@ -41,6 +41,7 @@ rosettaCode Maple
 
 linkedInSkill maple
  2018 51134
+officialBlogUrl https://faq.maplesoft.com/
 
 tiobe Maple
 hopl https://hopl.info/showlanguage.prx?exp=909


### PR DESCRIPTION
@breck7  I have reviewed the top 100 languages and at least most have the faq, release notes, annual report, events and official blog links added.  

Is there need to push to more languages. i.e top 200 