### PR TITLE
add download link for langs 1 to 35

### DIFF
--- a/database/things/arm.pldb
+++ b/database/things/arm.pldb
@@ -62,6 +62,7 @@ indeedJobs arm architecture developer
 linkedInSkill arm
  2018 110713
 faqPageUrl https://developer.arm.com/documentation/102870/latest/
+downloadPageUrl https://developer.arm.com/downloads/-/arm-compiler-for-embedded
 
 jupyterKernel https://github.com/DeepHorizons/iarm
 fileType text

--- a/database/things/common-lisp.pldb
+++ b/database/things/common-lisp.pldb
@@ -125,6 +125,7 @@ indeedJobs "common lisp"
  2017 24
 officialBlogUrl https://common-lisp.net/news
 faqPageUrl https://common-lisp.net/faq
+downloadPageUrl https://common-lisp.net/downloads
 
 tiobe Common Lisp
 hopl https://hopl.info/showlanguage.prx?exp=946

--- a/database/things/go.pldb
+++ b/database/things/go.pldb
@@ -282,6 +282,7 @@ stackOverflowSurvey
 releaseNotesUrl https://go.dev/doc/devel/release
 officialBlogUrl https://go.dev/blog/
 faqPageUrl https://go.dev/doc/faq
+downloadPageUrl https://go.dev/dl/
 
 meetup https://www.meetup.com/topics/golang
  memberCount 147668

--- a/database/things/haskell.pldb
+++ b/database/things/haskell.pldb
@@ -201,6 +201,7 @@ stackOverflowSurvey
   fans 3453
   percentageUsing 0.02
 faqPageUrl https://wiki.haskell.org/FAQ
+downloadPageUrl https://www.haskell.org/downloads/
 
 meetup https://www.meetup.com/topics/haskell
  memberCount 115163

--- a/database/things/lua.pldb
+++ b/database/things/lua.pldb
@@ -150,6 +150,10 @@ indeedJobs lua developer
  2022 736
 linkedInSkill lua
  2018 36954
+releaseNotesUrl https://www.lua.org/versions.html
+downloadPageUrl https://www.lua.org/download.html
+officialBlogUrl https://www.lua.org/news.html
+faqPageUrl https://www.lua.org/faq.html
 
 subreddit https://reddit.com/r/lua
  memberCount

--- a/database/things/mysql.pldb
+++ b/database/things/mysql.pldb
@@ -73,6 +73,7 @@ linkedInSkill mysql
 releaseNotesUrl https://dev.mysql.com/doc/relnotes/mysql/8.0/en/
 officialBlogUrl https://dev.mysql.com/blog-archive/
 faqPageUrl https://www.mysql.com/industry/faq/
+downloadPageUrl https://www.mysql.com/downloads/
 
 meetup https://www.meetup.com/topics/mysql
  memberCount 276432

--- a/database/things/pascal.pldb
+++ b/database/things/pascal.pldb
@@ -189,6 +189,7 @@ indeedJobs pascal developer
  2022 102
 releaseNotesUrl https://www.freepascal.org/news.html
 faqPageUrl https://www.freepascal.org/faq.html
+downloadPageUrl https://www.freepascal.org/download.html
 
 subreddit https://www.reddit.com/r/Pascal
  memberCount

--- a/database/things/perl.pldb
+++ b/database/things/perl.pldb
@@ -177,6 +177,7 @@ annualReportsUrl http://blogs.perl.org/users/mohammad_s_anwar/2022/01/
 releaseNotesUrl https://dev.perl.org/perl5/news/
 eventsPageUrl https://www.perl.org/events.html
 faqPageUrl https://perldoc.perl.org/perlfaq
+downloadPageUrl https://www.perl.org/get.html
 
 subreddit https://reddit.com/r/perl
  memberCount

--- a/database/things/php.pldb
+++ b/database/things/php.pldb
@@ -284,6 +284,7 @@ stackOverflowSurvey
 annualReportsUrl https://www.zend.com/blog/state-php-2022
 releaseNotesUrl https://www.php.net/releases/index.php
 eventsPageUrl https://www.php.net/cal.php
+downloadPageUrl https://www.php.net/downloads.php
 
 subreddit https://reddit.com/r/PHP
  memberCount

--- a/database/things/r.pldb
+++ b/database/things/r.pldb
@@ -163,6 +163,7 @@ stackOverflowSurvey
 releaseNotesUrl https://developer.r-project.org/
 officialBlogUrl https://developer.r-project.org/Blog/public/
 faqPageUrl https://cran.r-project.org/doc/FAQ/R-FAQ.html
+downloadPageUrl https://cran.r-project.org/bin/windows/base/
 
 subreddit https://reddit.com/r/Rlanguage
  memberCount

--- a/database/things/ruby.pldb
+++ b/database/things/ruby.pldb
@@ -263,6 +263,7 @@ stackOverflowSurvey
 releaseNotesUrl https://www.ruby-lang.org/en/downloads/releases/
 officialBlogUrl https://www.ruby-lang.org/en/community/weblogs/
 faqPageUrl https://www.ruby-lang.org/en/documentation/faq/
+downloadPageUrl https://www.ruby-lang.org/en/downloads/
 
 subreddit https://reddit.com/r/ruby
  memberCount

--- a/database/things/sas.pldb
+++ b/database/things/sas.pldb
@@ -104,6 +104,7 @@ indeedJobs sas programmer
  2022 1160
 linkedInSkill sas
  2018 352164
+faqPageUrl https://www.sas.com/en_us/certification/faq.html
 
 subreddit https://reddit.com/r/sas
  memberCount

--- a/database/things/scala.pldb
+++ b/database/things/scala.pldb
@@ -209,6 +209,7 @@ releaseNotesUrl https://www.scala-lang.org/download/all.html
 officialBlogUrl https://www.scala-lang.org/blog/
 eventsPageUrl https://scala-lang.org/events/
 faqPageUrl https://docs.scala-lang.org/tutorials/FAQ/index.html
+downloadPageUrl https://scala-lang.org/download/
 
 subreddit https://reddit.com/r/scala
  memberCount

--- a/database/things/swift.pldb
+++ b/database/things/swift.pldb
@@ -194,6 +194,8 @@ stackOverflowSurvey
   medianSalary 58911
   fans 6353
   percentageUsing 0.05
+officialBlogUrl https://www.swift.org/blog/  
+downloadPageUrl https://www.swift.org/download/
 
 subreddit https://reddit.com/r/swift
  memberCount

--- a/database/things/typescript.pldb
+++ b/database/things/typescript.pldb
@@ -226,6 +226,7 @@ stackOverflowSurvey
   percentageUsing 0.3
 releaseNotesUrl https://www.typescriptlang.org/docs/handbook/release-notes/
 officialBlogUrl https://devblogs.microsoft.com/typescript/
+downloadPageUrl https://www.typescriptlang.org/download
 
 subreddit https://reddit.com/r/typescript
  memberCount


### PR DESCRIPTION
@breck7  @celtic-coder  adding download link for langs 1 to 35 

 What should happen for cases of Installation guide may be from a GitHub repo?  Where there is no direct download option. If the installation happens from a link using a command. 