### PR TITLE
Update incorrectly typed esolangs

### DIFF
--- a/database/things/aheui.pldb
+++ b/database/things/aheui.pldb
@@ -1,6 +1,6 @@
 title Aheui
 appeared 2012
-type pl
+type esolang
 website http://aheui.github.io/aheuicon
 country Korea
 nativeLanguage Korean

--- a/database/things/blank.pldb
+++ b/database/things/blank.pldb
@@ -1,6 +1,6 @@
 title blank
 appeared 2018
-type pl
+type esolang
 website https://esolangs.org/wiki/Blank
 country Poland
 

--- a/database/things/brainfuck.pldb
+++ b/database/things/brainfuck.pldb
@@ -1,6 +1,6 @@
 title Brainfuck
 appeared 1993
-type pl
+type esolang
 creators Urban Müller
 description A nsfw esolang.
 documentation https://gist.github.com/roachhd/dce54bec8ba55fb17d3a

--- a/database/things/esoteric-reaction.pldb
+++ b/database/things/esoteric-reaction.pldb
@@ -1,6 +1,6 @@
 title Esoteric Reaction
 appeared 2020
-type pl
+type esolang
 country Unknown
 originCommunity https://bigyihsuan.github.io
 

--- a/database/things/piet-programming-language.pldb
+++ b/database/things/piet-programming-language.pldb
@@ -1,6 +1,6 @@
 title Piet
 appeared 1990
-type pl
+type esolang
 country Australia
 originCommunity https://www.dangermouse.net/esoteric/piet.html
 


### PR DESCRIPTION
This [query](https://pldb.com/search?q=select+type%0D%0Aincludes+esolang%0D%0Awhere+type+doesNotInclude+esolang%0D%0AsortBy+type):

![esolang-query](https://user-images.githubusercontent.com/11787866/216844764-c7c83b81-da4a-450b-9bc5-f2e94b75dc58.png)
shows that the following esolongs are incorrectly flagged as `pl` (programming language):

- Aheui
- blank
- Brainfuck
- Esoteric Reaction
- Piet

*Note:* I am leaving [checkout](https://pldb.com/languages/checkout.html) as type "assembly", as it is more appropriate than flagging it as an esolang.