### PR TITLE
Add appeared in sdms.pldb

### DIFF
--- a/database/things/sdms.pldb
+++ b/database/things/sdms.pldb
@@ -1,4 +1,5 @@
 title SDMS
+appeared 2001
 type pl
 reference https://ips-lmu.github.io/The-EMU-SDMS-Manual/chap-querysys-impl.html
 


### PR DESCRIPTION
info from: https://github.com/stevecassidy/emuR

because https://ips-lmu.github.io/The-EMU-SDMS-Manual/chap-querysys-impl.html goes to https://github.com/IPS-LMU/emuR/blob/master/R/emuR-query.database.R that is a fork from https://github.com/stevecassidy/emuR