### PR TITLE
update antlr.domain to iappend WWW as part of domain

### DIFF
--- a/database/grammar/antlr.grammar
+++ b/database/grammar/antlr.grammar
@@ -2,4 +2,4 @@ antlrNode
  extends abstractUrlGuidNode
  description A link to the ANTLR grammar for this language (https://github.com/antlr/grammars-v4/tree/master/LANGUAGE)
  cruxFromId
- string sourceDomain antlr.org
+ string sourceDomain www.antlr.org


### PR DESCRIPTION
Trying to work on issue https://github.com/breck7/pldb/issues/459
Domain names could allow www string to be added for pragmatic reasons and easily decrease new users perception of errors/faults 