### PR TITLE
Update WebAssembly Creator

### DIFF
--- a/database/things/wasm.pldb
+++ b/database/things/wasm.pldb
@@ -1,7 +1,7 @@
 title WebAssembly
 appeared 2015
 type bytecode
-creators Ben Smith
+creators Alon Zakai
 website http://webassembly.org/
 documentation https://developer.mozilla.org/en-US/docs/WebAssembly
 fileExtensions wasm


### PR DESCRIPTION
Alon Zakai is a co-creator of WebAssembly as per https://www.infoq.com/news/2020/05/webassembly-summit-2020-apie/ As noted, Ben Smith is the chair of the WebAssembly community group.