### PR TITLE
Adding more info for batch: alternate comment style and goto

### DIFF
--- a/truebase/things/batch.pldb
+++ b/truebase/things/batch.pldb
@@ -14,6 +14,11 @@ features
   REM A comment
  hasComments true
   REM A comment
+  :: Another type of comment
+ hasGotos
+  :: this would create an endless loop
+  :myLabel
+  goto myLabel
 
 lineCommentToken REM
 printToken echo


### PR DESCRIPTION
A batch file can be commented with `::` as well, (refer to https://ss64.com/nt/rem.html ). Additionally, batch files have the ability to `GOTO` something.