### PR TITLE
Update sako.scroll and klipa.scroll

### DIFF
--- a/concepts/klipa.scroll
+++ b/concepts/klipa.scroll
@@ -7,7 +7,7 @@ tags pl
 
 centralPackageRepositoryCount 0
 country Poland
-originCommunity Polish Academy of Science
+originCommunity Polish Academy of Sciences
 reference https://semanticscholar.org/paper/2b42fa947dbd72233d95dee1f4085b2bf156fbf0
 
 hopl https://hopl.info/showlanguage.prx?exp=2695

--- a/concepts/sako.scroll
+++ b/concepts/sako.scroll
@@ -1,7 +1,7 @@
 import ../code/conceptPage.scroll
 
 id sako
-name System Automatycznego Kodowania
+name SAKO
 appeared 1960
 tags pl
 standsFor System Automatycznego Kodowania
@@ -14,15 +14,46 @@ originCommunity Polish Academy of Sciences
 reference https://historiainformatyki.pl/skan.php?doc_id=1489&type=pdf&for_download=1
 
 assignmentToken =
+lineCommentToken K)
 
+canWriteToDisk true
+ PISZ NA BEBEN OD 10: A 
 isCaseSensitive false
 hasWhileLoops false
 hasClasses false
+hasLineComments true
 hasComments true
  K) A comment
+ : Also a comment (although, rarer and newer)
+ K) Comments must start at the beginning of a line
 hasGotos true
-hasBitWiseOperators true
 hasScientificNotation true
+hasFloats true
+ A = 2.3
+hasImports true
+hasIntegers true
+ CALKOWITE: I
+ I = 80766866
+hasZeroBasedNumbering true
+hasIncrementAndDecrementOperators false
+hasLineComments true
+ K) A comment
+hasMultiLineComments false
+hasCaseInsensitiveIdentifiers true
+hasAssignment true
+hasBitWiseOperators true
+hasOperators true
+ 1 + 1 - 1 × 1 * 1 / 1
+hasPrintDebugging true
+ TEKST:
+ HI
+hasLists true
+ TABLICA(4): B
+ 1 2.0 3.4
+ 4.1 5.6
+ *
+hasInfixNotation true
+ I = 3 + 4
 
 wikipedia https://en.wikipedia.org/wiki/SAKO_(programming_language)
  example
@@ -37,7 +68,6 @@ wikipedia https://en.wikipedia.org/wiki/SAKO_(programming_language)
  created 2013
  backlinksCount 4
  revisionCount 12
- appeared 1960
 
 hopl https://hopl.info/showlanguage.prx?exp=2178
 


### PR DESCRIPTION
 In `sako.scroll` :
- Changed `name` from `System Automatycznego Kodowania` to `SAKO`. I think this is a good change, because CSS, HTML and other languages with lenghty names have their abbreviations in the `name` fields, and we have the full name in the `standsFor` field.
- Added more information about SAKO language.
- Removed duplicate `appeared` field.

In `klipa.scroll` I changed `Polish Academy of Science` to it's correct form `Polish Academy of Sciences`