### PR TITLE
Add pragtical

### DIFF
--- a/concepts/pragtical.scroll
+++ b/concepts/pragtical.scroll
@@ -1,0 +1,22 @@
+import ../code/conceptPage.scroll
+
+id pragtical
+name Pragtical
+website https://pragtical.dev/
+description Pragtical is a lightweight, powerful, and hyperextensible text editor.
+tags textEditor
+writtenIn lua c
+
+features
+ - syntax highlighting
+ - multiple cursors
+ - command palette
+ - LSP support
+ - plugin support
+
+crossPlatformSupport
+ - Windows
+ - Linux
+ - macOS
+
+license MIT


### PR DESCRIPTION
Fixes #566

Add a new entry for Pragtical in the concepts directory.

* **New file `concepts/pragtical.scroll`**
  - Import `conceptPage.scroll`
  - Set `id` to `pragtical`
  - Set `name` to `Pragtical`
  - Set `website` to `https://pragtical.dev/`
  - Add a brief description of Pragtical
  - Add tags `textEditor`
  - Specify `writtenIn` as `lua` and `c`
  - List features including syntax highlighting, multiple cursors, command palette, LSP support, and plugin support
  - Mention cross-platform support for Windows, Linux, and macOS
  - Specify license as MIT

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/breck7/pldb/issues/566?shareId=1eb1aad6-33e9-406e-8912-a6e83004dd74).