### PR TITLE
Update clojure.scroll and clojurescript.scroll

### DIFF
--- a/concepts/clojure.scroll
+++ b/concepts/clojure.scroll
@@ -133,6 +133,8 @@ hasOperatorOverloading true
 hasLineComments true
  ; A comment
 hasHomoiconicity true
+hasDynamicTyping true
+hasGarbageCollection true
 hasPrintDebugging true
 hasMultiLineComments true
  (comment A comment

--- a/concepts/clojurescript.scroll
+++ b/concepts/clojurescript.scroll
@@ -58,6 +58,8 @@ hasFloats true
 hasIntegers true
 hasLineComments true
 hasComments true
+hasDynamicTyping true
+hasGarbageCollection true
 
 domainName clojurescript.org
  registered 2011


### PR DESCRIPTION
Both Clojure and ClojureScript use dynamic typing (as a result of being a LISP dialect) and have garbage collection (as they run on the JVM and JavaScript, both of which support garbage collection).

References:

https://en.wikipedia.org/wiki/Clojure