### PR TITLE
Fix Git SVG Overlap with Header

### DIFF
--- a/TrueBaseTheme.css
+++ b/TrueBaseTheme.css
@@ -63,6 +63,7 @@ body {
 }
 
 .trueBaseThemeHeader {
+  margin-top: 46px; /* so that header does not overlap with source icon */
   margin-bottom: 10px;
 }
 .trueBaseThemeHeader a {


### PR DESCRIPTION
This PR solves https://github.com/breck7/pldb/issues/607

Turns out that the styling of the SVG button is due to how `viewSourceButton` in Scroll is implemented. 

But, here is a quick workaround that makes the app look like the following on small phones: 

![image](https://github.com/user-attachments/assets/3e858e84-4c25-4d00-ae6a-ea0d692600b7)