### PR TITLE
Add Python's match statement

### DIFF
--- a/concepts/python.scroll
+++ b/concepts/python.scroll
@@ -108,6 +108,23 @@ canWriteToDisk true
 hasDuckTyping true
 hasSingleDispatch true
 hasRegularExpressionsSyntaxSugar false
+hasSwitch true
+ match x:
+   case 0:
+     print("zero")
+   case 1:
+     print("one")
+   case _:
+     print(f"other: {x}")
+hasPatternMatching true
+ def get_two_ends(l):
+   match l:
+     case [first, *_, last]:
+       return (first, last)
+     case [_] | []:
+       raise ValueError("list is too short to have two ends")
+     case _:
+       raise ValueError("not a list")
 hasCaseInsensitiveIdentifiers false
 hasTernaryOperators true
  print(1 if 1 else 0)


### PR DESCRIPTION
Python 3.10 introduced the `match` statement with [PEP 634](https://peps.python.org/pep-0634/).

It's uncontroversial that this can do everything `switch` statements in other languages can do, so this PR first adds it as an example of the [Switch Statements](https://pldb.io/features/hasSwitch.html) feature.

Arguably, it also fits the [Pattern Matching](https://pldb.io/features/hasPatternMatching.html) feature - the title of PEP 634 is "Structural Pattern Matching", after all. I'm sure that certain purists would disagree, e.g. because it can't be used as an expression and is not by default statically checked as being exhaustive (type checkers can [optionally check for exhaustiveness](https://typing.python.org/en/latest/guides/unreachable.html#assert-never-and-exhaustiveness-checking), however). But given that some of the other entries in Pattern Matching seem to suffer from the same limitations (e.g. the examples for Felix and Coconut don't seem like expressions), I've added it for the Pattern Matching feature as well. Maybe there could be "sub-features" for "Pattern Matching Expressions" and "Exhaustive Pattern Matching" to more clearly distinguish languages' exact capabilities in that area.