### PR TITLE
Add Python Destructuring feature

### DIFF
--- a/concepts/python.scroll
+++ b/concepts/python.scroll
@@ -146,6 +146,12 @@ hasDirectives true
 hasSinglePassParser false
 hasAssignment true
  name = "John"
+hasDestructuring true
+ # destructuring is implemented for simple sequence types, including nested:
+ (a, (b, c), *d) = (1, (2, 3), 4, 5, 6)  # result: a=1, b=2, c=3, d=(4,5,6)
+
+ # but it is NOT implemented for more complicated types like dictionaries:
+ {"a": a} = {"a": 1}  # ERROR
 hasImports true
  import datetime
  oTime = datetime.datetime.now()


### PR DESCRIPTION
Python implements the [Destructuring](https://pldb.io/features/hasDestructuring.html) feature for simple sequence types, so this PR documents that fact.
Also includes an example of its limitations, i.e. that it doesn't work for more complicated types like dictionaries.