### PR TITLE
Add Type Classes feature

### DIFF
--- a/code/measures.parsers
+++ b/code/measures.parsers
@@ -1649,6 +1649,12 @@ hasTypeAnnotationsParser
  string title Type Annotations
  string pseudoExample score: number
 
+hasTypeClassesParser
+ extends abstractFeatureParser
+ description Does the language have type classes?
+ string title Type Classes
+ string reference https://en.wikipedia.org/wiki/Type_class
+
 hasTypeInferenceParser
  extends abstractFeatureParser
  description Can the parser infer the type of a variable at compile time without an annotation?

--- a/concepts/c.scroll
+++ b/concepts/c.scroll
@@ -199,6 +199,7 @@ hasImports true
 hasNamespaces false
 hasMultipleInheritance false
 hasTemplates false
+hasTypeClasses false
 hasIntegers true
  int pldb = 80766866;
 hasMacros true

--- a/concepts/coq.scroll
+++ b/concepts/coq.scroll
@@ -52,6 +52,7 @@ hasMultiLineComments true
  (* a comment *)
 hasDependentTypes true
  (* http://www-sop.inria.fr/members/Yves.Bertot/tsinghua/tsinghua-1.pdf *)
+hasTypeClasses true
 hasOctals true
 hasHexadecimals true
 hasFloats true

--- a/concepts/cpp.scroll
+++ b/concepts/cpp.scroll
@@ -227,6 +227,34 @@ hasVirtualFunctions true
      std::cout << "Llamas eat grass!" << std::endl;
    }
  };
+hasTypeClasses true
+ #include <iostream>
+ #include <string>
+
+ using namespace std;
+
+ // NOTE that in contrast to other typeclass-supporting languages,
+ // concept (= typeclass) implementations
+ // a) MUST be defined BEFORE the concept is introduced and
+ // b) do not reference the concept directly, because the association
+ //    is structural, not nominal.
+ string toTypedJson(int x) {
+   return "{\"type\": \"int\", \"value\": " + to_string(x) + "}";
+ }
+
+ template <typename T>
+ concept ToTypedJson = requires (T a) {
+   {toTypedJson(a)} -> convertible_to<string>;
+ };
+
+ template <ToTypedJson T>
+ void printAsTypedJson(T x) {
+   cout << toTypedJson(x) << endl;
+ }
+
+ int main() {
+   printAsTypedJson(123);
+ }
 hasThreads true
 hasClasses true
 hasExceptions true

--- a/concepts/haskell.scroll
+++ b/concepts/haskell.scroll
@@ -83,6 +83,21 @@ hasRunTimeGuards true
  f x
   | x > 0 = 1
   | otherwise = 0
+hasTypeClasses true
+ class ToTypedJson a where
+   toTypedJson :: a -> String
+
+ instance ToTypedJson Integer where
+   toTypedJson x =
+     "{\"type\": \"int\", \"value\": " ++ (show x) ++ "}"
+
+ printAsTypedJson :: ToTypedJson a => a -> IO ()
+ printAsTypedJson x = do
+   putStrLn (toTypedJson x)
+
+ main :: IO ()
+ main = do
+   printAsTypedJson (123 :: Integer)
 hasTypedHoles true
  -- Found hole `_' with type f (Free f b)
 hasMonads true

--- a/concepts/idris.scroll
+++ b/concepts/idris.scroll
@@ -87,6 +87,7 @@ hasFloats true
  -- \d+[eE][+-]?\d+
 hasIntegers true
  -- \d+
+hasTypeClasses true
 
 wikipedia https://en.wikipedia.org/wiki/Idris_(programming_language)
  example

--- a/concepts/java.scroll
+++ b/concepts/java.scroll
@@ -128,6 +128,7 @@ hasGenerics true
  v.add("test");
  Integer i = v.get(0); // (type error)  compilation-time error
 hasSingleDispatch true
+hasTypeClasses false
 hasPointers false
 hasStrings true
  "hello world"

--- a/concepts/javascript.scroll
+++ b/concepts/javascript.scroll
@@ -262,6 +262,7 @@ hasSwitch true
   case "dog": console.log("yay"); break;
   case "cat": console.log("oh"); break;
  }
+hasTypeClasses false
 hasTernaryOperators true
  let i = true ? 1 : 0
 hasWhileLoops true

--- a/concepts/kotlin.scroll
+++ b/concepts/kotlin.scroll
@@ -120,6 +120,8 @@ hasMacros false
 hasOperatorOverloading true
 hasSemanticIndentation false
 hasCaseInsensitiveIdentifiers false
+hasTypeClasses false
+ https://github.com/Kotlin/KEEP/pull/87#issuecomment-746042751
 hasTypeInference true
 hasLineComments true
  // A comment

--- a/concepts/ocaml.scroll
+++ b/concepts/ocaml.scroll
@@ -68,6 +68,8 @@ hasComments true
   * comment.
   *)
 hasMultipleInheritance true
+hasTypeClasses false
+ supposedly modules offer similar functionality: https://accu.org/journals/overload/25/142/fletcher_2445/
 hasTypeInference true
 hasModules true
  (* In OCaml, every piece of code is wrapped into a module. *)

--- a/concepts/python.scroll
+++ b/concepts/python.scroll
@@ -107,6 +107,7 @@ canWriteToDisk true
   filehandle.write('Hello, world!\n')
 hasDuckTyping true
 hasSingleDispatch true
+hasTypeClasses false
 hasRegularExpressionsSyntaxSugar false
 hasSwitch true
  match x:

--- a/concepts/rust.scroll
+++ b/concepts/rust.scroll
@@ -171,6 +171,25 @@ hasPrintDebugging true
  println!("Hi");
 hasSemanticIndentation false
 hasCaseInsensitiveIdentifiers false
+hasTypeClasses true
+ // https://doc.rust-lang.org/book/ch10-02-traits.html
+ trait ToTypedJson {
+   fn to_typed_json(&self) -> String;
+ }
+
+ impl ToTypedJson for i64 {
+   fn to_typed_json(&self) -> String {
+     return format!("{{\"type\": \"int\", \"value\": {}}}", self)
+   }
+ }
+
+ fn print_as_typed_json(x: impl ToTypedJson) {
+   println!("{}", x.to_typed_json());
+ }
+
+ fn main() {
+   print_as_typed_json(123);
+ }
 hasTypeInference true
 hasLineComments true
  // A comment

--- a/concepts/scala.scroll
+++ b/concepts/scala.scroll
@@ -129,6 +129,19 @@ hasImplicitArguments true
    }
  }
 hasOperatorOverloading true
+hasTypeClasses true
+ // https://docs.scala-lang.org/scala3/book/ca-type-classes.html
+ trait TypedJsonConvertible[A]:
+   extension (a: A) def toTypedJson: String
+
+ given TypedJsonConvertible[Int] with
+   extension (x: Int) def toTypedJson: String =
+     s"{\"type\": \"int\", \"value\": ${x}}"
+
+ def printAsTypedJson[T: TypedJsonConvertible](x: T): Unit =
+   println(x.toTypedJson);
+
+ printAsTypedJson(123);
 hasTypeInference true
 hasLineComments true
  // A comment

--- a/concepts/typescript.scroll
+++ b/concepts/typescript.scroll
@@ -152,6 +152,8 @@ hasInheritance true
  class B {}
  class A extends B {}
 hasStaticTyping true
+hasTypeClasses false
+  https://github.com/microsoft/TypeScript/issues/10844#issuecomment-256182331
 hasTypeParameters true
  function identity<T>(arg: T): T {
     return arg;


### PR DESCRIPTION
[Type classes](https://en.wikipedia.org/wiki/Type_class) (or something "close enough" like Rust's traits) are a feature of some modern languages with type systems inspired by Haskell (and Haskell itself, of course).

As far as I understand them, they are a way to define interfaces to which arbitrary types (including existing ones) may be made to conform, with the possibility to then use these interface types as function parameter types etc.

To facilitate comparisons between how different languages implement this feature, I used the same basic example for each language.