### PR TITLE
Fix typeclass indent and extend Python destructuring

### DIFF
--- a/concepts/cpp.scroll
+++ b/concepts/cpp.scroll
@@ -230,9 +230,9 @@ hasVirtualFunctions true
 hasTypeClasses true
  #include <iostream>
  #include <string>
-
+ 
  using namespace std;
-
+ 
  // NOTE that in contrast to other typeclass-supporting languages,
  // concept (= typeclass) implementations
  // a) MUST be defined BEFORE the concept is introduced and
@@ -241,17 +241,17 @@ hasTypeClasses true
  string toTypedJson(int x) {
    return "{\"type\": \"int\", \"value\": " + to_string(x) + "}";
  }
-
+ 
  template <typename T>
  concept ToTypedJson = requires (T a) {
    {toTypedJson(a)} -> convertible_to<string>;
  };
-
+ 
  template <ToTypedJson T>
  void printAsTypedJson(T x) {
    cout << toTypedJson(x) << endl;
  }
-
+ 
  int main() {
    printAsTypedJson(123);
  }

--- a/concepts/haskell.scroll
+++ b/concepts/haskell.scroll
@@ -86,15 +86,15 @@ hasRunTimeGuards true
 hasTypeClasses true
  class ToTypedJson a where
    toTypedJson :: a -> String
-
+ 
  instance ToTypedJson Integer where
    toTypedJson x =
      "{\"type\": \"int\", \"value\": " ++ (show x) ++ "}"
-
+ 
  printAsTypedJson :: ToTypedJson a => a -> IO ()
  printAsTypedJson x = do
    putStrLn (toTypedJson x)
-
+ 
  main :: IO ()
  main = do
    printAsTypedJson (123 :: Integer)

--- a/concepts/python.scroll
+++ b/concepts/python.scroll
@@ -165,11 +165,17 @@ hasSinglePassParser false
 hasAssignment true
  name = "John"
 hasDestructuring true
- # destructuring is implemented for simple sequence types, including nested:
+ # destructuring assignment works for sequences, including nested ones:
  (a, (b, c), *d) = (1, (2, 3), 4, 5, 6)  # result: a=1, b=2, c=3, d=(4,5,6)
-
- # but it is NOT implemented for more complicated types like dictionaries:
+ 
+ # it is NOT implemented for more complicated types like dictionaries:
  {"a": a} = {"a": 1}  # ERROR
+ 
+ # more complex destructuring is possible using the match statement:
+ d = {"a": {"b": [1, 2]}}
+ match d:
+   case {"a": {"b": [1, x]}}: pass  # result: x=2
+   case _: raise RuntimeError("destructuring failed!")
 hasImports true
  import datetime
  oTime = datetime.datetime.now()

--- a/concepts/python.scroll
+++ b/concepts/python.scroll
@@ -175,7 +175,7 @@ hasDestructuring true
  d = {"a": {"b": [1, 2]}}
  match d:
    case {"a": {"b": [1, x]}}: pass  # result: x=2
-   case _: raise RuntimeError("destructuring failed!")
+   case _: raise ValueError("destructuring failed!")
 hasImports true
  import datetime
  oTime = datetime.datetime.now()

--- a/concepts/rust.scroll
+++ b/concepts/rust.scroll
@@ -176,17 +176,17 @@ hasTypeClasses true
  trait ToTypedJson {
    fn to_typed_json(&self) -> String;
  }
-
+ 
  impl ToTypedJson for i64 {
    fn to_typed_json(&self) -> String {
      return format!("{{\"type\": \"int\", \"value\": {}}}", self)
    }
  }
-
+ 
  fn print_as_typed_json(x: impl ToTypedJson) {
    println!("{}", x.to_typed_json());
  }
-
+ 
  fn main() {
    print_as_typed_json(123);
  }

--- a/concepts/scala.scroll
+++ b/concepts/scala.scroll
@@ -133,14 +133,14 @@ hasTypeClasses true
  // https://docs.scala-lang.org/scala3/book/ca-type-classes.html
  trait TypedJsonConvertible[A]:
    extension (a: A) def toTypedJson: String
-
+ 
  given TypedJsonConvertible[Int] with
    extension (x: Int) def toTypedJson: String =
      s"{\"type\": \"int\", \"value\": ${x}}"
-
+ 
  def printAsTypedJson[T: TypedJsonConvertible](x: T): Unit =
    println(x.toTypedJson);
-
+ 
  printAsTypedJson(123);
 hasTypeInference true
 hasLineComments true


### PR DESCRIPTION
Looking at the [rendered form of the Type Class examples](https://pldb.io/features/hasTypeClasses.html) I introduced in #626, they're all cut off at the first empty newline. Comparing to the other examples with empty newlines, they all have indentation even for the empty lines, which my examples are missing, so that's probably the reason.

The Python destructuring example had the same issue so this PR fixes that as well, and while we're at it, extends it by another way to achieve destructuring in Python (using the `match` statement added in #624).

Sorry that I missed all of this the first time around!