### PR TITLE
Add Named Arguments feature

### DIFF
--- a/code/measures.parsers
+++ b/code/measures.parsers
@@ -1321,6 +1321,12 @@ hasMultipleInheritanceParser
  string pseudoExample extends parentWhichExtendsSomethingElse
  string reference https://en.wikipedia.org/wiki/Multiple_inheritance
 
+hasNamedArgumentsParser
+ extends abstractFeatureParser
+ description Does the language have named arguments / named parameters?
+ string title Named Arguments
+ string reference https://en.wikipedia.org/wiki/Named_parameter
+
 hasNamespacesParser
  extends abstractFeatureParser
  description Does the language have a namespace construct?

--- a/concepts/bash.scroll
+++ b/concepts/bash.scroll
@@ -92,6 +92,8 @@ hasImports true
  source ./bash.sh
 hasWhileLoops true
 hasFunctions true
+hasFunctionOverloading false
+hasNamedArguments false
 hasConditionals true
 hasStandardLibrary true
  echo "Hello, World!"

--- a/concepts/c.scroll
+++ b/concepts/c.scroll
@@ -253,6 +253,9 @@ hasConstants true
 hasConditionals true
 hasFixedPoint false
 hasScientificNotation true
+hasFunctions true
+hasFunctionOverloading false
+hasNamedArguments false
 hasStandardLibrary true
  #include <stdio.h>
 

--- a/concepts/cpp.scroll
+++ b/concepts/cpp.scroll
@@ -176,6 +176,7 @@ hasFunctionOverloading true
  double volume(const double r, const int h) {
    return 3.1415926*r*r*static_cast<double>(h);
  }
+hasNamedArguments false
 hasNamespaces true
  #include <iostream>
  using namespace std;

--- a/concepts/haskell.scroll
+++ b/concepts/haskell.scroll
@@ -146,6 +146,9 @@ hasCaseInsensitiveIdentifiers false
 hasTypeInference true
 hasLineComments true
  -- A comment
+hasFunctions true
+hasFunctionOverloading TODO
+hasNamedArguments false
 hasFunctionComposition true
  foo = f . g
 hasRangeOperators true

--- a/concepts/java.scroll
+++ b/concepts/java.scroll
@@ -133,6 +133,10 @@ hasPointers false
 hasStrings true
  "hello world"
 hasComments true
+hasFunctions true
+ TODO
+hasFunctionOverloading true
+hasNamedArguments false
 hasConstructors true
 hasGarbageCollection true
 hasImports true

--- a/concepts/javascript.scroll
+++ b/concepts/javascript.scroll
@@ -239,6 +239,8 @@ hasAnonymousFunctions true
  (() => console.log("hello world"))()
 hasMacros false
 hasFunctionOverloading false
+hasNamedArguments false
+ // idiomatically emulated using parameters that expect objects
 hasMultilineStrings true
  const lines = `one
  two`

--- a/concepts/kotlin.scroll
+++ b/concepts/kotlin.scroll
@@ -136,6 +136,9 @@ hasClasses true
 hasConstants true
 hasExceptions true
 hasFunctions true
+hasFunctionOverloading true
+hasNamedArguments true
+ "abcdef".subSequence(startIndex=2, endIndex=4)
 hasAccessModifiers true
 hasConditionals true
 hasStandardLibrary true

--- a/concepts/python.scroll
+++ b/concepts/python.scroll
@@ -264,6 +264,13 @@ hasPrintDebugging true
 isCaseSensitive true
 hasWhileLoops true
 hasFunctions true
+hasFunctionOverloading false
+ may be simulated using `**kwargs` or `functools.singledispatch`
+hasNamedArguments true
+ print("Hello", end="!\n")
+ 
+ # details: any parameter that hasn't been explicitly marked as positional-only
+ # can be provided as a named argument
 hasOctals true
  # 0[oO](?:_?[0-7])+
 hasHexadecimals true

--- a/concepts/ruby.scroll
+++ b/concepts/ruby.scroll
@@ -134,6 +134,15 @@ hasExceptions true
     end
   end
  hello
+hasNamedArguments true
+ String.new("abc", encoding: "utf-8", capacity: 16)
+
+ # details: when defining a method, parameters are positional-only by default,
+ # but can be made keyword parameters (i.e. named) by appending a colon (:),
+ # optionally followed by a default value:
+ def greet(name, time_of_day:, location: "our great city")
+   puts "Hello this fine #{time_of_day} in #{location}, #{name}!"
+ end
 hasFunctionOverloading false
 hasAsyncAwait false
 hasConstants true

--- a/concepts/rust.scroll
+++ b/concepts/rust.scroll
@@ -198,6 +198,9 @@ hasWhileLoops true
 hasConstants true
 hasSinglePassParser false
 hasConditionals true
+hasFunctions true
+hasFunctionOverloading false
+hasNamedArguments false
 hasStandardLibrary true
  println!("Hello, World!");
 

--- a/concepts/scala.scroll
+++ b/concepts/scala.scroll
@@ -157,6 +157,9 @@ hasWhileLoops true
 hasClasses true
 hasExceptions true
 hasFunctions true
+hasFunctionOverloading false
+hasNamedArguments true
+ "abcdef".slice(from=2, until=4)
 hasInheritance true
 hasConditionals true
 hasStandardLibrary true

--- a/concepts/typescript.scroll
+++ b/concepts/typescript.scroll
@@ -127,6 +127,8 @@ hasMixins true
  class SmartObject implements Disposable, Activatable {
  }
  // Note: still need to do some runtime ops to make that work.
+hasNamedArguments false
+ // idiomatically emulated using parameters that expect objects
 hasNamespaces true
  // Typescript even supports splitting namespaces across multiple files:
  // Validation.ts


### PR DESCRIPTION
# Description

A convenient feature many languages have is that they allow providing arguments to function calls by name rather than by position. E.g. in Python:

```python
def greet(name, location):
  print(f"Hello, {name} in {location}!")

greet(name="John", location="New York")
```

This PR adds this to PLDB as the `namedArguments` feature.

# Details

## Why "Named Arguments" and not "Named Parameters"?

The Wikipedia article about this feature is called ["Named parameters"](https://en.wikipedia.org/wiki/Named_parameter) and only lists "named arguments" as an alternative term, so why not call this feature "Named Parameters"?

Two reasons:

1. **Accuracy:** In most languages, the decision of whether to use this feature is made when _calling_ a function, so it pertains to arguments (given at the call site) rather than parameters (given at the definition site). Some languages like Ruby or Python _do_ allow enabling/restricting this feature for specific parameters when the function is defined, and for _that_ the term "Named Parameters" would be appropriate. But I would see that as a "sub-feature" of "Named Arguments" then.
2. **Popularity:** If you look at the Wikipedia article's own [References section](https://en.wikipedia.org/wiki/Named_parameter#References), you'll see that most titles are some variant of "Named Arguments", "Keyword Arguments" etc. because that's what most languages' docs themselves refer to this feature as. 