### PR TITLE
Add Structural Typing feature

### DIFF
--- a/code/measures.parsers
+++ b/code/measures.parsers
@@ -1622,6 +1622,12 @@ hasStructsParser
  string pseudoExample struct pldbFile { int rank; char *title; };
  string reference https://en.wikipedia.org/wiki/Struct_(C_programming_language)
 
+hasStructuralTypingParser
+ extends abstractFeatureParser
+ description Does the language feature (significant) structural typing?
+ string title Structural Typing
+ string reference https://en.wikipedia.org/wiki/Structural_type_system
+
 hasSwitchParser
  extends abstractFeatureParser
  description Does the language have switch statements or expressions?

--- a/concepts/bash.scroll
+++ b/concepts/bash.scroll
@@ -98,6 +98,7 @@ hasNamedArguments false
 hasConditionals true
 hasStandardLibrary true
  echo "Hello, World!"
+hasStructuralTyping false
 
 jupyterKernel https://github.com/takluyver/bash_kernel
 wikipedia https://en.wikipedia.org/wiki/Bash_(Unix_shell)

--- a/concepts/c.scroll
+++ b/concepts/c.scroll
@@ -199,6 +199,7 @@ hasImports true
 hasNamespaces false
 hasMultipleInheritance false
 hasTemplates false
+hasStructuralTyping false
 hasTypeClasses false
 hasIntegers true
  int pldb = 80766866;

--- a/concepts/cpp.scroll
+++ b/concepts/cpp.scroll
@@ -227,17 +227,14 @@ hasVirtualFunctions true
      std::cout << "Llamas eat grass!" << std::endl;
    }
  };
-hasTypeClasses true
+hasStructuralTyping true
+ // concepts use structural typing:
  #include <iostream>
  #include <string>
  
  using namespace std;
  
- // NOTE that in contrast to other typeclass-supporting languages,
- // concept (= typeclass) implementations
- // a) MUST be defined BEFORE the concept is introduced and
- // b) do not reference the concept directly, because the association
- //    is structural, not nominal.
+ // NOTE that concept implementations MUST be defined BEFORE the concept itself
  string toTypedJson(int x) {
    return "{\"type\": \"int\", \"value\": " + to_string(x) + "}";
  }
@@ -255,6 +252,7 @@ hasTypeClasses true
  int main() {
    printAsTypedJson(123);
  }
+hasTypeClasses false
 hasThreads true
 hasClasses true
 hasExceptions true

--- a/concepts/java.scroll
+++ b/concepts/java.scroll
@@ -129,6 +129,8 @@ hasGenerics true
  v.add("test");
  Integer i = v.get(0); // (type error)  compilation-time error
 hasSingleDispatch true
+hasStructuralTyping false
+ https://stackoverflow.com/q/44484287
 hasTypeClasses false
 hasPointers false
 hasStrings true

--- a/concepts/javascript.scroll
+++ b/concepts/javascript.scroll
@@ -263,6 +263,7 @@ hasSwitch true
   case "dog": console.log("yay"); break;
   case "cat": console.log("oh"); break;
  }
+hasStructuralTyping false
 hasTypeClasses false
 hasTernaryOperators true
  let i = true ? 1 : 0

--- a/concepts/kotlin.scroll
+++ b/concepts/kotlin.scroll
@@ -121,6 +121,8 @@ hasMacros false
 hasOperatorOverloading true
 hasSemanticIndentation false
 hasCaseInsensitiveIdentifiers false
+hasStructuralTyping false
+ https://youtrack.jetbrains.com/issue/KT-218
 hasTypeClasses false
  https://github.com/Kotlin/KEEP/pull/87#issuecomment-746042751
 hasTypeInference true

--- a/concepts/ocaml.scroll
+++ b/concepts/ocaml.scroll
@@ -68,6 +68,7 @@ hasComments true
   * comment.
   *)
 hasMultipleInheritance true
+hasStructuralTyping true
 hasTypeClasses false
  supposedly modules offer similar functionality: https://accu.org/journals/overload/25/142/fletcher_2445/
 hasTypeInference true

--- a/concepts/python.scroll
+++ b/concepts/python.scroll
@@ -107,6 +107,42 @@ canWriteToDisk true
  with open('helloworld.txt', 'w') as filehandle:
   filehandle.write('Hello, world!\n')
 hasDuckTyping true
+hasStructuralTyping true
+ # Python's optional static type system features 2 kinds of structural types:
+ from typing import Protocol
+ 
+ class Clearable(Protocol):
+   def clear(self): ...
+ 
+ def print_and_clear(x: Clearable):
+   print(x)
+   x.clear()
+ 
+ print_and_clear([1, 2, 3])  # OK because lists have a clear() method
+ print_and_clear({1, 2, 3})  # OK because sets have a clear() method
+ print_and_clear(1)          # not OK because ints don't have a clear() method
+ 
+ from typing import TypedDict
+ 
+ class NameDict(TypedDict):
+   first_name: str
+   last_name: str
+ 
+ class EmployeeDict(TypedDict):
+   employee_id: int
+   first_name: str
+   last_name: str
+ 
+ def greet(name: NameDict):
+   print(f"Hello {name['first_name']} {name['last_name']}!")
+ 
+ john: EmployeeDict = {
+   "first_name": "John", "last_name": "Smith", "employee_id": 123
+ }
+ 
+ # EmployeeDict is a (structural) subtype of NameDict even though there is no
+ # explicit relation between them, so this passes type checking:
+ greet(john)
 hasSingleDispatch true
 hasTypeClasses false
 hasRegularExpressionsSyntaxSugar false

--- a/concepts/rust.scroll
+++ b/concepts/rust.scroll
@@ -172,6 +172,11 @@ hasPrintDebugging true
  println!("Hi");
 hasSemanticIndentation false
 hasCaseInsensitiveIdentifiers false
+hasStructuralTyping false
+ tuples can be seen as structural, [1] but other fundamental types like structs
+ and traits are not structural and don't have structural analogues
+
+ [1]: https://doc.rust-lang.org/reference/types/tuple.html
 hasTypeClasses true
  // https://doc.rust-lang.org/book/ch10-02-traits.html
  trait ToTypedJson {

--- a/concepts/scala.scroll
+++ b/concepts/scala.scroll
@@ -129,6 +129,19 @@ hasImplicitArguments true
    }
  }
 hasOperatorOverloading true
+hasStructuralTyping true
+ // https://docs.scala-lang.org/scala3/reference/changed-features/structural-types.html#using-java-reflection-1
+ import scala.reflect.Selectable.reflectiveSelectable
+ 
+ type Reversable[T] = { def reverse: T }
+ 
+ def printReversed[T](x: Reversable[T]): Unit = {
+   println(x.reverse)
+ }
+ 
+ printReversed("abc")
+ printReversed(Array(1, 2, 3))
+ printReversed(1)  // Doesn't compile because integers don't have a reverse method
 hasTypeClasses true
  // https://docs.scala-lang.org/scala3/book/ca-type-classes.html
  trait TypedJsonConvertible[A]:

--- a/concepts/typescript.scroll
+++ b/concepts/typescript.scroll
@@ -154,6 +154,23 @@ hasPrintDebugging true
 hasInheritance true
  class B {}
  class A extends B {}
+hasStructuralTyping true
+ // https://www.typescriptlang.org/docs/handbook/type-compatibility.html
+ // Subtype relations are structural for both interfaces and classes.
+ // Interface example:
+ interface CanCheckIncludes<T> {
+     includes(x: T): boolean;
+ }
+ 
+ function logIfIncludes<T>(includer: CanCheckIncludes<T>, includee: T) {
+     if (includer.includes(includee)) {
+         console.log(includer);
+     }
+ }
+ 
+ logIfIncludes("abc", "b");
+ logIfIncludes([1, 2, 3], 4);
+ logIfIncludes(1, 1);  // Fails typechecking, as numbers don't have includes()
 hasStaticTyping true
 hasTypeClasses false
   https://github.com/microsoft/TypeScript/issues/10844#issuecomment-256182331


### PR DESCRIPTION
Fixes #630.

As described at the end of #630, I went with the option of just putting this under a general "Structural Typing" feature. It may not be entirely accurate, as the Rust and Java examples show where some very simple types like tuples and arrays could be "seen as structural", but I hope that's fine for now. It can be made more precise in the future by introducing new features describing _which kinds of types_ are structural or have structural analogues.

Also as described in #630, I moved C++ concepts from Type Classes to Structural Typing.