### PR TITLE
Apply Static Typing feature to more languages

### DIFF
--- a/concepts/bash.scroll
+++ b/concepts/bash.scroll
@@ -98,6 +98,7 @@ hasNamedArguments false
 hasConditionals true
 hasStandardLibrary true
  echo "Hello, World!"
+hasStaticTyping false
 hasStructuralTyping false
 
 jupyterKernel https://github.com/takluyver/bash_kernel

--- a/concepts/c.scroll
+++ b/concepts/c.scroll
@@ -199,6 +199,7 @@ hasImports true
 hasNamespaces false
 hasMultipleInheritance false
 hasTemplates false
+hasStaticTyping true
 hasStructuralTyping false
 hasTypeClasses false
 hasIntegers true

--- a/concepts/cpp.scroll
+++ b/concepts/cpp.scroll
@@ -227,6 +227,7 @@ hasVirtualFunctions true
      std::cout << "Llamas eat grass!" << std::endl;
    }
  };
+hasStaticTyping true
 hasStructuralTyping true
  // concepts use structural typing:
  #include <iostream>

--- a/concepts/haskell.scroll
+++ b/concepts/haskell.scroll
@@ -82,6 +82,7 @@ hasRunTimeGuards true
  f x
   | x > 0 = 1
   | otherwise = 0
+hasStaticTyping true
 hasTypeClasses true
  class ToTypedJson a where
    toTypedJson :: a -> String

--- a/concepts/java.scroll
+++ b/concepts/java.scroll
@@ -129,6 +129,7 @@ hasGenerics true
  v.add("test");
  Integer i = v.get(0); // (type error)  compilation-time error
 hasSingleDispatch true
+hasStaticTyping true
 hasStructuralTyping false
  https://stackoverflow.com/q/44484287
 hasTypeClasses false

--- a/concepts/javascript.scroll
+++ b/concepts/javascript.scroll
@@ -263,6 +263,7 @@ hasSwitch true
   case "dog": console.log("yay"); break;
   case "cat": console.log("oh"); break;
  }
+hasStaticTyping false
 hasStructuralTyping false
 hasTypeClasses false
 hasTernaryOperators true

--- a/concepts/kotlin.scroll
+++ b/concepts/kotlin.scroll
@@ -121,6 +121,7 @@ hasMacros false
 hasOperatorOverloading true
 hasSemanticIndentation false
 hasCaseInsensitiveIdentifiers false
+hasStaticTyping true
 hasStructuralTyping false
  https://youtrack.jetbrains.com/issue/KT-218
 hasTypeClasses false

--- a/concepts/ocaml.scroll
+++ b/concepts/ocaml.scroll
@@ -68,6 +68,7 @@ hasComments true
   * comment.
   *)
 hasMultipleInheritance true
+hasStaticTyping true
 hasStructuralTyping true
 hasTypeClasses false
  supposedly modules offer similar functionality: https://accu.org/journals/overload/25/142/fletcher_2445/

--- a/concepts/python.scroll
+++ b/concepts/python.scroll
@@ -107,6 +107,15 @@ canWriteToDisk true
  with open('helloworld.txt', 'w') as filehandle:
   filehandle.write('Hello, world!\n')
 hasDuckTyping true
+hasTypeAnnotations true
+ name: str
+hasStaticTyping true
+ # Optional, checkable using external type checkers like Mypy or Pyright
+ def print_repeated(text: str, repetitions: int) -> None:
+   print("\n".join([text]*repetitions))
+ 
+ print_repeated("Hello!", 10)
+ print_repeated("This won't typecheck...", "not an integer")
 hasStructuralTyping true
  # Python's optional static type system features 2 kinds of structural types:
  from typing import Protocol

--- a/concepts/rust.scroll
+++ b/concepts/rust.scroll
@@ -172,6 +172,7 @@ hasPrintDebugging true
  println!("Hi");
 hasSemanticIndentation false
 hasCaseInsensitiveIdentifiers false
+hasStaticTyping true
 hasStructuralTyping false
  tuples can be seen as structural, [1] but other fundamental types like structs
  and traits are not structural and don't have structural analogues

--- a/concepts/scala.scroll
+++ b/concepts/scala.scroll
@@ -129,6 +129,7 @@ hasImplicitArguments true
    }
  }
 hasOperatorOverloading true
+hasStaticTyping true
 hasStructuralTyping true
  // https://docs.scala-lang.org/scala3/reference/changed-features/structural-types.html#using-java-reflection-1
  import scala.reflect.Selectable.reflectiveSelectable


### PR DESCRIPTION
While preparing #631, I noticed that there is a "Static Typing" feature, but it hasn't been applied to a lot of languages yet. So this applies it to some.

For Python specifically, I also added the "Type Annotations" feature (which is so far only used by 3 languages). I don't know if that makes sense for the other languages... e.g. in C, types are not so much "annotations" as mandatory parts of variable declarations :shrug: 