### PR TITLE
Add Lateralus programming language

### DIFF
--- a/concepts/lateralus.scroll
+++ b/concepts/lateralus.scroll
@@ -1,0 +1,39 @@
+id lateralus
+name Lateralus
+appeared 2025
+creators bad-antics
+tags pl
+website https://lateralus.dev
+lab grug-group420
+fileExtensions lat
+
+isOpenSource true
+github https://github.com/bad-antics/lateralus-lang
+documentation https://grug-group420.github.io/docs
+
+description A pipeline-native programming language with compiler, VM, OS, LSP, and VS Code extension. Features algebraic data types, pattern matching, type inference, and borrow checking.
+
+writtenIn rust c assembly-language python shell
+compilesTo c llvm wasm
+
+hasComments true
+hasLineComments true
+hasSemanticIndentation false
+hasTyping true
+hasStaticTyping true
+hasTypeInference true
+hasPatternMatching true
+hasAlgebraicTypes true
+hasBorrowChecking true
+hasCompilerParts true
+
+lineCommentToken //
+printToken print
+
+helloWorldCollection
+ print "Hello, World!"
+
+example
+ fn factorial(n: i32) -> i32 =
+   | 0 => 1
+   | n => n * factorial(n - 1)


### PR DESCRIPTION
## Lateralus

Adding Lateralus to PLDB - a pipeline-native programming language.

### Language Overview
- **Name**: Lateralus
- **Appeared**: 2025
- **Creator**: bad-antics / grug-group420
- **File Extension**: .lat

### Key Features
- Pipeline-native syntax
- Algebraic data types (sum/product types)
- Pattern matching with guards
- Type inference (Hindley-Milner style)
- Borrow checking for memory safety
- Multiple backends: C, LLVM, WASM

### Ecosystem
- **Compiler**: Rust-based compiler with C backend
- **VM**: Custom virtual machine
- **OS**: Bare-metal OS support
- **LSP**: Language Server Protocol implementation
- **VS Code Extension**: Full IDE support

### Links
- Website: https://lateralus.dev
- Repository: https://github.com/bad-antics/lateralus-lang
- Documentation: https://grug-group420.github.io/docs