### PR TITLE
Add Cobrust language

### DIFF
--- a/concepts/cobrust.scroll
+++ b/concepts/cobrust.scroll
@@ -1,0 +1,62 @@
+../code/conceptPage.scroll
+
+id cobrust
+name Cobrust
+appeared 2026
+creators Cobrust contributors
+tags pl
+website https://github.com/cobrust-lang/cobrust
+description Cobrust is a statically typed Python successor implemented in Rust with an AI-native compiler that closed-loop translates the Python ecosystem. It keeps Python ergonomics (indentation blocks, comprehensions, pattern matching, f-strings) while adopting Rust's ownership model and Result/Option error handling. No GIL, no implicit truthiness, no mutable default arguments. Targets Cranelift and LLVM backends. File extension: .cb
+fileExtensions cb
+license Apache-2.0 OR MIT
+isOpenSource true
+writtenIn rust toml markdown
+
+githubRepo https://github.com/cobrust-lang/cobrust
+ stars 0
+ forks 0
+ created 2026
+
+compilesTo llvm-ir
+
+influencedBy python rust
+
+country International
+
+lineCommentToken #
+printToken print
+assignmentToken =
+stringToken "
+booleanTokens true false
+
+hasComments true
+hasSemanticIndentation true
+hasStaticTyping true
+hasPrintDebugging true
+hasPatternMatching true
+hasGenerics true
+hasEnums true
+hasFirstClassFunctions true
+hasLambda true
+hasStrings true
+ "Hello, world!"
+hasBooleans true
+hasBooleans true
+hasIntegers true
+hasFloats true
+hasLineComments true
+ # This is a comment
+
+leachim6 Cobrust
+ filepath c/Cobrust.cb
+ fileExtensions cb
+ example
+  print("Hello World")
+
+example
+ fn greet(name: str) -> str:
+     f"Hello, {name}!"
+
+ fn main():
+     result = greet("World")
+     print(result)


### PR DESCRIPTION
Adds Cobrust to PLDB.

**Language**: Cobrust — statically-typed Python successor implemented in Rust with an AI-native translation subsystem.

**Repository**: https://github.com/Cobrust-lang/cobrust
**License**: Apache-2.0 OR MIT (dual)
**First public release**: v0.3.0 (2026-05-18)
**Current release**: v0.5.2 (2026-05-22)
**Implementation language**: Rust 1.94+
**Extension**: `.cb`

Cobrust keeps Python ergonomics (indentation blocks, comprehensions, structural pattern matching, f-strings) while adopting Rust's ownership model, `Result<T,E>` / `Option<T>` error handling, and zero-GIL concurrency. The compiler includes an AI-native translation subsystem that closed-loop converts Python libraries into Cobrust under differential testing verification.

Design constraints that distinguish it from other Python successors:
- No implicit truthiness (`if x` requires `x: bool`)
- No mutable default arguments (compile error)
- No multiple inheritance (composition + traits)
- `Result<T,E>` as default error path; exceptions reserved for unrecoverable conditions
- Ownership-based concurrency, no global lock
- LLM-first design (every choice optimised for "LLM agents write it correctly on the first try" — see `CLAUDE.md` §2.5)

## Cross-references

- v0.5.2 release: https://github.com/Cobrust-lang/cobrust/releases/tag/v0.5.2
- VSCode/Cursor extension (Open VSX): https://open-vsx.org/extension/cobrust-lang/cobrust
- TextMate grammar: https://github.com/Cobrust-lang/cobrust-tmlanguage
- github-linguist PR (parallel): github-linguist/linguist#7977